### PR TITLE
Updating default cni plugins version to 1.7.1

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -37,9 +37,9 @@ The following parameters are available in the `cni_plugins` class:
 
 Data type: `String`
 
-The version of the CNI plugins to install (default: 1.6.2)
+The version of the CNI plugins to install (default: 1.7.1)
 
-Default value: `'1.6.2'`
+Default value: `'1.7.1'`
 
 ##### <a name="-cni_plugins--install_root"></a>`install_root`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 # archives.
 #
 # @param version
-#   The version of the CNI plugins to install (default: 1.6.2)
+#   The version of the CNI plugins to install (default: 1.7.1)
 #
 # @param install_root
 #   The root into which the cni plugins should be installed (default: /opt/cni)
@@ -21,7 +21,7 @@
 # @example
 #   include cni_plugins
 class cni_plugins (
-  String               $version = '1.6.2',
+  String               $version = '1.7.1',
   Stdlib::Absolutepath $install_root = '/opt/cni',
   Stdlib::Filemode     $install_root_mode = '0755',
   String               $install_root_owner = 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "avitacco-cni_plugins",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Anthony Vitacco",
   "summary": "A module for installing and updating the CNI plugins",
   "license": "MIT",

--- a/spec/classes/cni_plugins_spec.rb
+++ b/spec/classes/cni_plugins_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 describe 'cni_plugins' do
+  let(:version) { '1.7.1' }
+
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
@@ -32,7 +34,7 @@ describe 'cni_plugins' do
             mode: '0755',
           )
 
-        is_expected.to contain_file('/opt/cni/1.6.2')
+        is_expected.to contain_file("/opt/cni/#{version}")
           .with(
             ensure: 'directory',
             owner: 'root',
@@ -41,23 +43,23 @@ describe 'cni_plugins' do
           )
           .that_requires(['File[/opt/cni]'])
 
-        is_expected.to contain_archive('cni-plugins-linux-amd64-v1.6.2.tgz')
+        is_expected.to contain_archive("cni-plugins-linux-amd64-v#{version}.tgz")
           .with(
-            path: '/tmp/cni-plugins-linux-amd64-v1.6.2.tgz',
-            source: 'https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz',
-            digest_url: 'https://github.com/containernetworking/plugins/releases/download/v1.6.2/cni-plugins-linux-amd64-v1.6.2.tgz.sha512',
+            path: "/tmp/cni-plugins-linux-amd64-v#{version}.tgz",
+            source: "https://github.com/containernetworking/plugins/releases/download/v#{version}/cni-plugins-linux-amd64-v#{version}.tgz",
+            digest_url: "https://github.com/containernetworking/plugins/releases/download/v#{version}/cni-plugins-linux-amd64-v#{version}.tgz.sha512",
             digest_type: 'sha512',
             extract: true,
-            extract_path: '/opt/cni/1.6.2',
+            extract_path: "/opt/cni/#{version}",
           )
-          .that_requires(['File[/opt/cni/1.6.2]'])
+          .that_requires(["File[/opt/cni/#{version}]"])
 
         is_expected.to contain_file('/opt/cni/bin')
           .with(
             ensure: 'link',
-            target: '/opt/cni/1.6.2',
+            target: "/opt/cni/#{version}",
           )
-          .that_requires(['Archive[cni-plugins-linux-amd64-v1.6.2.tgz]'])
+          .that_requires(["Archive[cni-plugins-linux-amd64-v#{version}.tgz]"])
       }
     end
 


### PR DESCRIPTION
* Fixes #1
* Updates tests to have a version variable to make default version updates easier in the future
* Bumping version in metadata